### PR TITLE
fix path in launchd profile, avoid always needs refresh after upgraded

### DIFF
--- a/Formula/trojan.rb
+++ b/Formula/trojan.rb
@@ -30,7 +30,7 @@ class Trojan < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>#{bin}/trojan</string>
+        <string>#{opt_bin}/trojan</string>
         <string>-c</string>
         <string>#{etc}/trojan/config.json</string>
       </array>


### PR DESCRIPTION
Original launchd profile always use absolute bin path, which contains version string(like /usr/local/Cellar/trojan/1.15.0/bin/trojan), which makes user needs to `brew services stop trojan` and `brew services start trojan` for just refresh the path after each version upgrading, or next boot the service will refuse to launch. 
This PR eliminate this need via replacing absolute bin path by the opt_bin path(like /usr/local/opt/trojan/bin/trojan), which keeps between versions. 