### PR TITLE
Add support for building on M1 Mac

### DIFF
--- a/Formula/trojan.rb
+++ b/Formula/trojan.rb
@@ -16,26 +16,8 @@ class Trojan < Formula
     system "make", "install"
   end
 
-  plist_options :manual => "trojan #{HOMEBREW_PREFIX}/etc/trojan/config.json"
-
-  def plist; <<~EOS
-  <?xml version="1.0" encoding="UTF-8"?>
-  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-  <plist version="1.0">
-    <dict>
-      <key>KeepAlive</key>
-      <true/>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/trojan</string>
-        <string>#{etc}/trojan/config.json</string>
-      </array>
-    </dict>
-  </plist>
-  EOS
+  service do
+    run [opt_bin/"trojan", etc/"trojan/config.json"]
+    keep_alive true
   end
 end

--- a/Formula/trojan.rb
+++ b/Formula/trojan.rb
@@ -11,7 +11,7 @@ class Trojan < Formula
 
   def install
     system "sed", "-i", "", "s/server\\.json/client.json/", "CMakeLists.txt"
-    system "sed", "-i", "", "s/${CMAKE_INSTALL_FULL_SYSCONFDIR}/#{HOMEBREW_PREFIX.to_s.gsub('/', '\/')}\\/etc/", "CMakeLists.txt"
+    system "sed", "-i", "", "s:${CMAKE_INSTALL_FULL_SYSCONFDIR}:#{etc}:", "CMakeLists.txt"
     system "cmake", ".", *std_cmake_args, "-DENABLE_MYSQL=OFF"
     system "make", "install"
   end

--- a/Formula/trojan.rb
+++ b/Formula/trojan.rb
@@ -11,6 +11,7 @@ class Trojan < Formula
 
   def install
     system "sed", "-i", "", "s/server\\.json/client.json/", "CMakeLists.txt"
+    system "sed", "-i", "", "s/${CMAKE_INSTALL_FULL_SYSCONFDIR}/#{HOMEBREW_PREFIX.to_s.gsub('/', '\/')}\\/etc/", "CMakeLists.txt"
     system "cmake", ".", *std_cmake_args, "-DENABLE_MYSQL=OFF"
     system "make", "install"
   end

--- a/Formula/trojan.rb
+++ b/Formula/trojan.rb
@@ -5,7 +5,7 @@ class Trojan < Formula
   sha256 "86cdb2685bb03a63b62ce06545c41189952f1ec4a0cd9147450312ed70956cbc"
   depends_on "cmake" => :build
   depends_on "boost"
-  depends_on "openssl@1.1"
+  depends_on "openssl"
   depends_on "python" => :test
   depends_on "coreutils" => :test
 


### PR DESCRIPTION
1. Change `CMAKE_INSTALL_FULL_SYSCONFDIR` to `#{etc}`
2. Calling `plist_options` is deprecated! Use `service` instead.
3. [openssl@1.1 (deprecated)](https://formulae.brew.sh/formula/openssl@1.1)